### PR TITLE
Update python library versions in PDF Langchain Lab

### DIFF
--- a/PDF_QnA_with_LangChain_Vertex_AI_PaLM_API.ipynb
+++ b/PDF_QnA_with_LangChain_Vertex_AI_PaLM_API.ipynb
@@ -172,10 +172,11 @@
    ],
    "source": [
     "# Install Python Libraries\n",
-    "!pip install --user chromadb --quiet\n",
+    "!pip install --user chromadb==0.4.15 --quiet\n",
     "!pip install --user langchain==0.0.157 --quiet\n",
     "!pip install --user google-cloud-core --quiet\n",
     "!pip install --user gradio --quiet\n",
+    "!pip install --user pydantic==1.10.13 --quiet\n",
     "\n",
     "# Below libraries are required to build a SQL engine for BigQuery\n",
     "!pip install --user SQLAlchemy==1.4.48 --quiet\n",


### PR DESCRIPTION
Updated python libraries to chromadb v0.4.15 and pydantic to 1.10.13 to avoid breaking changes during the rest of the lab.